### PR TITLE
🌈 优化iOS导出logo图标的体验

### DIFF
--- a/QiAppIconGenerator.xcodeproj/project.pbxproj
+++ b/QiAppIconGenerator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04B7C2E123ACCF6800F6BB2C /* Contents.json in Resources */ = {isa = PBXBuildFile; fileRef = 04B7C2E023ACCF6800F6BB2C /* Contents.json */; };
 		063420AA2240D3DF00C9AE9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 063420A92240D3DF00C9AE9A /* AppDelegate.m */; };
 		063420AD2240D3DF00C9AE9A /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 063420AC2240D3DF00C9AE9A /* ViewController.m */; };
 		063420AF2240D3E100C9AE9A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 063420AE2240D3E100C9AE9A /* Assets.xcassets */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		04B7C2E023ACCF6800F6BB2C /* Contents.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Contents.json; sourceTree = "<group>"; };
 		063420A52240D3DF00C9AE9A /* QiAppIconGenerator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QiAppIconGenerator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		063420A82240D3DF00C9AE9A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		063420A92240D3DF00C9AE9A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 				063420A92240D3DF00C9AE9A /* AppDelegate.m */,
 				063420AB2240D3DF00C9AE9A /* ViewController.h */,
 				063420AC2240D3DF00C9AE9A /* ViewController.m */,
+				04B7C2E023ACCF6800F6BB2C /* Contents.json */,
 				063420BC2240D65100C9AE9A /* QiConfiguration.plist */,
 				063420AE2240D3E100C9AE9A /* Assets.xcassets */,
 				063420B02240D3E100C9AE9A /* Main.storyboard */,
@@ -133,6 +136,7 @@
 				063420BD2240D65100C9AE9A /* QiConfiguration.plist in Resources */,
 				063420AF2240D3E100C9AE9A /* Assets.xcassets in Resources */,
 				063420B22240D3E100C9AE9A /* Main.storyboard in Resources */,
+				04B7C2E123ACCF6800F6BB2C /* Contents.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QiAppIconGenerator/Contents.json
+++ b/QiAppIconGenerator/Contents.json
@@ -1,0 +1,62 @@
+{
+  "images" : [
+    {
+      "size" : "20x20",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-20@2x",
+      "scale" : "2x"
+    },
+    {
+      "size" : "20x20",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-20@3x",
+      "scale" : "3x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-29@2x",
+      "scale" : "1x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-29@3x",
+      "scale" : "2x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-40@2x",
+      "scale" : "2x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-40@3x",
+      "scale" : "3x"
+    },
+    {
+      "size" : "60x60",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-60@2x",
+      "scale" : "2x"
+    },
+    {
+      "size" : "60x60",
+      "idiom" : "iphone",
+      "filename" : "AppIcon-iPhone-60@3x",
+      "scale" : "3x"
+    },
+    {
+      "size" : "1024x1024",
+      "idiom" : "ios-marketing",
+      "filename" : "AppIcon-AppStore-1024.png",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/QiAppIconGenerator/Contents.json
+++ b/QiAppIconGenerator/Contents.json
@@ -1,62 +1,68 @@
 {
-  "images" : [
-    {
-      "size" : "20x20",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-20@2x",
-      "scale" : "2x"
-    },
-    {
-      "size" : "20x20",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-20@3x",
-      "scale" : "3x"
-    },
-    {
-      "size" : "29x29",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-29@2x",
-      "scale" : "1x"
-    },
-    {
-      "size" : "29x29",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-29@3x",
-      "scale" : "2x"
-    },
-    {
-      "size" : "40x40",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-40@2x",
-      "scale" : "2x"
-    },
-    {
-      "size" : "40x40",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-40@3x",
-      "scale" : "3x"
-    },
-    {
-      "size" : "60x60",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-60@2x",
-      "scale" : "2x"
-    },
-    {
-      "size" : "60x60",
-      "idiom" : "iphone",
-      "filename" : "AppIcon-iPhone-60@3x",
-      "scale" : "3x"
-    },
-    {
-      "size" : "1024x1024",
-      "idiom" : "ios-marketing",
-      "filename" : "AppIcon-AppStore-1024.png",
-      "scale" : "1x"
+    "images" : [
+        {
+            "size" : "20x20",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-20@2x.png",
+            "scale" : "2x"
+        },
+        {
+            "size" : "20x20",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-20@3x.png",
+            "scale" : "3x"
+        },
+        {
+            "size" : "29x29",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-29.png",
+            "scale" : "1x"
+        },
+        {
+            "size" : "29x29",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-29@2x.png",
+            "scale" : "2x"
+        },
+        {
+            "size" : "29x29",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-29@3x.png",
+            "scale" : "3x"
+        },
+        {
+            "size" : "40x40",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-40@2x.png",
+            "scale" : "2x"
+        },
+        {
+            "size" : "40x40",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-40@3x.png",
+            "scale" : "3x"
+        },
+        {
+            "size" : "60x60",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-60@2x.png",
+            "scale" : "2x"
+        },
+        {
+            "size" : "60x60",
+            "idiom" : "iphone",
+            "filename" : "AppIcon-iPhone-60@3x.png",
+            "scale" : "3x"
+        },
+        {
+            "size" : "1024x1024",
+            "idiom" : "ios-marketing",
+            "filename" : "AppIcon-AppStore-1024.png",
+            "scale" : "1x"
+        }
+    ],
+    "info" : {
+        "version" : 1,
+        "author" : "xcode"
     }
-  ],
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  }
 }

--- a/QiAppIconGenerator/QiConfiguration.plist
+++ b/QiAppIconGenerator/QiConfiguration.plist
@@ -22,6 +22,14 @@
 		</dict>
 		<dict>
 			<key>purpose</key>
+			<string>iPhone Settings 1x</string>
+			<key>name</key>
+			<string>AppIcon-iPhone-29</string>
+			<key>size</key>
+			<string>{29,29}</string>
+		</dict>
+		<dict>
+			<key>purpose</key>
 			<string>iPhone Settings 2x</string>
 			<key>name</key>
 			<string>AppIcon-iPhone-29@2x</string>

--- a/QiAppIconGenerator/ViewController.m
+++ b/QiAppIconGenerator/ViewController.m
@@ -83,8 +83,19 @@ static NSString * const exportedPathKey = @"exportedPath";
     NSArray<NSDictionary *> *items = configuration[platform];
     
     NSString *directoryPath = [[_pathField.stringValue stringByAppendingPathComponent:platform] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    [[NSFileManager defaultManager] createDirectoryAtPath:directoryPath withIntermediateDirectories:YES attributes:nil error:nil];
     
+    ///FIXME:- 导出iOS图标时 优化处理一下(直接拖入`AppIcon.appiconset`替换即可 不用一张一张填空)
+    if ([platform isEqualToString:@"iPhone AppIcons"]) {
+        directoryPath = [[_pathField.stringValue stringByAppendingPathComponent:@"AppIcon.appiconset"] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        [[NSFileManager defaultManager] createDirectoryAtPath:directoryPath withIntermediateDirectories:YES attributes:nil error:nil];
+        NSString *contentJsonPath = [[NSBundle mainBundle] pathForResource:@"Contents" ofType:@"json"];
+        NSData *data = [NSData dataWithContentsOfFile:contentJsonPath options:(NSDataReadingMappedIfSafe) error:nil];
+        NSString *filePath = [NSString stringWithFormat:@"%@/Contents.json", directoryPath];
+        [data writeToFile:filePath atomically:YES];
+    }else{
+        [[NSFileManager defaultManager] createDirectoryAtPath:directoryPath withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+
     if ([platform containsString:@"AppIcons"]) {
         [self generateAppIconsWithConfigurations:items fromOriginalImage:originalImage toDirectoryPath:directoryPath];
     }


### PR DESCRIPTION
之前手动裁剪一张1024x1024的图片,就觉得很烦,因为花费比较多的时间处理图片。 
后来用过在线工具[图标工场](https://icon.wuruihong.com/) 确实也很不错, 就是有时网速不好的时候，产品那边又急着催~  网络不好的时候这款工具就比较实用了, 综合比较之后，觉得体验有点不好,我是做`iOS`所以只优化了这一块~   所以来`pull request`一下试试看
